### PR TITLE
Add --symlink_repo option for creating symlinks from sql command

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -66,7 +66,7 @@ repos:
     rev: v0.971
     hooks:
       - id: mypy
-        language_version: python3.8
+        language_version: python3
 
   - repo: https://github.com/adrienverge/yamllint.git
     rev: v1.26.3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -66,7 +66,7 @@ repos:
     rev: v0.971
     hooks:
       - id: mypy
-        language_version: python3
+        language_version: python3.8
 
   - repo: https://github.com/adrienverge/yamllint.git
     rev: v1.26.3

--- a/src/omero_mkngff/__init__.py
+++ b/src/omero_mkngff/__init__.py
@@ -204,7 +204,8 @@ class MkngffControl(BaseControl):
             self.ctx.err(f"Checking for prefix_dir {prefix_dir}")
             if not os.path.exists(prefix_dir):
                  self.ctx.die(402, f"Fileset dir does not exist: {prefix_dir}")
-            symlink_dir = os.path.join(f"{prefix_dir}_converted", symlink_path.parent)
+            # symlink_dir = os.path.join(f"{prefix_dir}_converted", symlink_path.parent)
+            symlink_dir = f"{prefix_dir}_converted/{symlink_path.parent}"
             self.ctx.err(f"Creating dir at {symlink_dir}")
             os.makedirs(symlink_dir, exist_ok=True)
 

--- a/src/omero_mkngff/__init__.py
+++ b/src/omero_mkngff/__init__.py
@@ -219,6 +219,8 @@ class MkngffControl(BaseControl):
 
         rows = []
         for row_path, row_name, row_mime in self.walk(symlink_path):
+            if str(row_path).startswith("/"):
+                row_path = str(row_path)[1:]  # remove "/" from start
             rows.append(
                 ROW.format(
                     PATH=f"{prefix_path}/{prefix_name}_converted/{row_path}/",

--- a/src/omero_mkngff/__init__.py
+++ b/src/omero_mkngff/__init__.py
@@ -18,6 +18,7 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
+import os
 from argparse import Namespace
 from pathlib import Path
 from typing import Generator, Tuple
@@ -154,6 +155,11 @@ class MkngffControl(BaseControl):
             "--secret", help="DB UUID for protecting SQL statements", default="TBD"
         )
         sql.add_argument("--zarr_name", help="Nicer name for zarr directory if desired")
+        sql.add_argument(
+            "--symlink_repo",
+            help=("Create symlinks from Fileset to symlink_target using"
+                  "this ManagedRepo path, e.g. /data/OMERO/ManagedRepository")
+        )
         sql.add_argument("fileset_id", type=int)
         sql.add_argument("symlink_target")
         sql.set_defaults(func=self.sql)
@@ -191,9 +197,20 @@ class MkngffControl(BaseControl):
             self.ctx.die(401, f"Symlink target does not exist: {args.symlink_target}")
             return
 
-        zarr_name = args.zarr_name
-        if not zarr_name:
-            zarr_name = symlink_path.name
+        # create *_converted/path/to/zarr directory containing symlink to data
+        if args.symlink_repo:
+            prefix_dir = os.path.join(args.symlink_repo, prefix_path)
+            if not os.path.exists(prefix_dir):
+                 self.ctx.die(402, f"Fileset dir does not exist: {prefix_dir}")
+            symlink_dir = os.path.join(prefix_dir, f"{prefix_name}_converted", symlink_path.parent)
+            os.makedirs(symlink_dir, exist_ok=True)
+
+            symlink_source = os.path.join(symlink_dir, symlink_path.name)
+            target_is_directory = os.path.isdir(args.symlink_target)
+            self.ctx.err(
+                f"Creating symlink {symlink_source} -> {args.symlink_target}"
+            )
+            os.symlink(args.symlink_target, symlink_source, target_is_directory)
 
         rows = []
         for row_path, row_name, row_mime in self.walk(symlink_path):

--- a/src/omero_mkngff/__init__.py
+++ b/src/omero_mkngff/__init__.py
@@ -199,7 +199,6 @@ class MkngffControl(BaseControl):
 
         # create *_converted/path/to/zarr directory containing symlink to data
         if args.symlink_repo:
-            self.ctx.err(f"Using args.symlink_repo: {args.symlink_repo}")
             prefix_dir = os.path.join(args.symlink_repo, prefix)
             self.ctx.err(f"Checking for prefix_dir {prefix_dir}")
             if not os.path.exists(prefix_dir):
@@ -208,7 +207,7 @@ class MkngffControl(BaseControl):
             if symlink_container.startswith("/"):
                 symlink_container = symlink_container[1:]  # remove "/" from start
             symlink_dir = os.path.join(f"{prefix_dir}_converted", symlink_container)
-            self.ctx.err(f"Creating dir at {symlink_dir} symlink_container: {symlink_container}")
+            self.ctx.err(f"Creating dir at {symlink_dir}")
             os.makedirs(symlink_dir, exist_ok=True)
 
             symlink_source = os.path.join(symlink_dir, symlink_path.name)

--- a/src/omero_mkngff/__init__.py
+++ b/src/omero_mkngff/__init__.py
@@ -199,10 +199,11 @@ class MkngffControl(BaseControl):
 
         # create *_converted/path/to/zarr directory containing symlink to data
         if args.symlink_repo:
-            prefix_dir = os.path.join(args.symlink_repo, prefix_path)
+            prefix_dir = os.path.join(args.symlink_repo, prefix)
             if not os.path.exists(prefix_dir):
                  self.ctx.die(402, f"Fileset dir does not exist: {prefix_dir}")
-            symlink_dir = os.path.join(prefix_dir, f"{prefix_name}_converted", symlink_path.parent)
+            symlink_dir = os.path.join(f"{prefix_dir}_converted", symlink_path.parent)
+            self.ctx.err(f"Creating dir at {symlink_dir}")
             os.makedirs(symlink_dir, exist_ok=True)
 
             symlink_source = os.path.join(symlink_dir, symlink_path.name)

--- a/src/omero_mkngff/__init__.py
+++ b/src/omero_mkngff/__init__.py
@@ -199,7 +199,9 @@ class MkngffControl(BaseControl):
 
         # create *_converted/path/to/zarr directory containing symlink to data
         if args.symlink_repo:
+            self.ctx.err(f"Using args.symlink_repo: {args.symlink_repo}")
             prefix_dir = os.path.join(args.symlink_repo, prefix)
+            self.ctx.err(f"Checking for prefix_dir {prefix_dir}")
             if not os.path.exists(prefix_dir):
                  self.ctx.die(402, f"Fileset dir does not exist: {prefix_dir}")
             symlink_dir = os.path.join(f"{prefix_dir}_converted", symlink_path.parent)

--- a/src/omero_mkngff/__init__.py
+++ b/src/omero_mkngff/__init__.py
@@ -204,9 +204,10 @@ class MkngffControl(BaseControl):
             self.ctx.err(f"Checking for prefix_dir {prefix_dir}")
             if not os.path.exists(prefix_dir):
                  self.ctx.die(402, f"Fileset dir does not exist: {prefix_dir}")
-            symlink_dir = os.path.join(f"{prefix_dir}_converted", str(symlink_path.parent))
+            symlink_container = f"{symlink_path.parent}"
+            symlink_dir = os.path.join(f"{prefix_dir}_converted", symlink_container)
             # symlink_dir = f"{prefix_dir}_converted/{symlink_path.parent}"
-            self.ctx.err(f"Creating dir at {symlink_dir}")
+            self.ctx.err(f"Creating dir at {symlink_dir} symlink_container: {symlink_container}")
             os.makedirs(symlink_dir, exist_ok=True)
 
             symlink_source = os.path.join(symlink_dir, symlink_path.name)

--- a/src/omero_mkngff/__init__.py
+++ b/src/omero_mkngff/__init__.py
@@ -204,8 +204,8 @@ class MkngffControl(BaseControl):
             self.ctx.err(f"Checking for prefix_dir {prefix_dir}")
             if not os.path.exists(prefix_dir):
                  self.ctx.die(402, f"Fileset dir does not exist: {prefix_dir}")
-            # symlink_dir = os.path.join(f"{prefix_dir}_converted", symlink_path.parent)
-            symlink_dir = f"{prefix_dir}_converted/{symlink_path.parent}"
+            symlink_dir = os.path.join(f"{prefix_dir}_converted", str(symlink_path.parent))
+            # symlink_dir = f"{prefix_dir}_converted/{symlink_path.parent}"
             self.ctx.err(f"Creating dir at {symlink_dir}")
             os.makedirs(symlink_dir, exist_ok=True)
 

--- a/src/omero_mkngff/__init__.py
+++ b/src/omero_mkngff/__init__.py
@@ -205,8 +205,9 @@ class MkngffControl(BaseControl):
             if not os.path.exists(prefix_dir):
                  self.ctx.die(402, f"Fileset dir does not exist: {prefix_dir}")
             symlink_container = f"{symlink_path.parent}"
+            if symlink_container.startswith("/"):
+                symlink_container = symlink_container[1:]  # remove "/" from start
             symlink_dir = os.path.join(f"{prefix_dir}_converted", symlink_container)
-            # symlink_dir = f"{prefix_dir}_converted/{symlink_path.parent}"
             self.ctx.err(f"Creating dir at {symlink_dir} symlink_container: {symlink_container}")
             os.makedirs(symlink_dir, exist_ok=True)
 


### PR DESCRIPTION
Fixes #3.

Usage:

```
omero mkngff sql --symlink_repo data/OMERO/ManagedRepository 601 /path/to/fileset.zarr
```


I looked at trying to use the OMERO API to lookup the `omero.data.dir` but for that you need to be logged-in as root, which limits usefulness.

```
>>> cs = conn.c.sf.getConfigService()
>>> cs.getConfigValues("omero.data.dir")
{}
>>> cs.getConfigDefaults()["omero.data.dir"]
serverExceptionClass = ome.conditions.SecurityViolation
    message = No matching roles found in [Public, user] for session fabc9b94-c6cd-4799-863b-fb1a8f5785cc (allowed: [system])
```