### PR TITLE
Always update pixels

### DIFF
--- a/src/omero_mkngff/__init__.py
+++ b/src/omero_mkngff/__init__.py
@@ -27,7 +27,7 @@ import omero.all  # noqa
 from omero.cli import BaseControl, Parser
 from omero.sys import ParametersI
 
-SUFFIX = "converted"
+SUFFIX = "mkngff"
 HELP = """Plugin to swap OMERO filesets with NGFF
 
 CLI plugin used to swap an existing OMERO fileset with

--- a/src/omero_mkngff/__init__.py
+++ b/src/omero_mkngff/__init__.py
@@ -232,6 +232,11 @@ class MkngffControl(BaseControl):
                 )
             )
 
+        # Add a command to update the Pixels table with path/name using old Fileset ID *before* new Fileset is created
+        fpath = setid_target[0]
+        fname = setid_target[1]
+        self.ctx.out(f"UPDATE pixels SET name = '{fname}', path = '{fpath}' where image in (select id from Image where fileset = {args.fileset_id});")
+
         self.ctx.out(
             TEMPLATE.format(
                 OLD_FILESET=args.fileset_id,
@@ -241,11 +246,6 @@ class MkngffControl(BaseControl):
                 UUID=args.secret,
             )
         )
-
-        # Add a command to update the Pixels table with path/name
-        fpath = setid_target[0]
-        fname = setid_target[1]
-        self.ctx.out(f"UPDATE pixels SET name = '{fname}', path = '{fpath}' where image in (select id from Image where fileset ={args.fileset_id});")
 
     def walk(self, path: Path) -> Generator[Tuple[Path, str, str], None, None]:
         for p in path.iterdir():

--- a/src/omero_mkngff/__init__.py
+++ b/src/omero_mkngff/__init__.py
@@ -207,7 +207,7 @@ class MkngffControl(BaseControl):
             symlink_container = f"{symlink_path.parent}"
             if symlink_container.startswith("/"):
                 symlink_container = symlink_container[1:]  # remove "/" from start
-            symlink_dir = os.path.join(f"{prefix_dir}_{SUFFIX}", symlink_container)
+            symlink_dir = f"{prefix_dir}_{SUFFIX}"
             self.ctx.err(f"Creating dir at {symlink_dir}")
             os.makedirs(symlink_dir, exist_ok=True)
 
@@ -220,6 +220,8 @@ class MkngffControl(BaseControl):
 
         rows = []
         for row_path, row_name, row_mime in self.walk(symlink_path):
+            # remove common path to shorten
+            row_path = str(row_path).replace(f"{symlink_path.parent}", "")
             if str(row_path).startswith("/"):
                 row_path = str(row_path)[1:]  # remove "/" from start
             rows.append(

--- a/src/omero_mkngff/__init__.py
+++ b/src/omero_mkngff/__init__.py
@@ -27,6 +27,7 @@ import omero.all  # noqa
 from omero.cli import BaseControl, Parser
 from omero.sys import ParametersI
 
+SUFFIX = "converted"
 HELP = """Plugin to swap OMERO filesets with NGFF
 
 CLI plugin used to swap an existing OMERO fileset with
@@ -197,7 +198,7 @@ class MkngffControl(BaseControl):
             self.ctx.die(401, f"Symlink target does not exist: {args.symlink_target}")
             return
 
-        # create *_converted/path/to/zarr directory containing symlink to data
+        # create *_SUFFIX/path/to/zarr directory containing symlink to data
         if args.symlink_repo:
             prefix_dir = os.path.join(args.symlink_repo, prefix)
             self.ctx.err(f"Checking for prefix_dir {prefix_dir}")
@@ -206,7 +207,7 @@ class MkngffControl(BaseControl):
             symlink_container = f"{symlink_path.parent}"
             if symlink_container.startswith("/"):
                 symlink_container = symlink_container[1:]  # remove "/" from start
-            symlink_dir = os.path.join(f"{prefix_dir}_converted", symlink_container)
+            symlink_dir = os.path.join(f"{prefix_dir}_{SUFFIX}", symlink_container)
             self.ctx.err(f"Creating dir at {symlink_dir}")
             os.makedirs(symlink_dir, exist_ok=True)
 
@@ -223,7 +224,7 @@ class MkngffControl(BaseControl):
                 row_path = str(row_path)[1:]  # remove "/" from start
             rows.append(
                 ROW.format(
-                    PATH=f"{prefix_path}/{prefix_name}_converted/{row_path}/",
+                    PATH=f"{prefix_path}/{prefix_name}_{SUFFIX}/{row_path}/",
                     NAME=row_name,
                     MIME=row_mime,
                 )
@@ -232,7 +233,7 @@ class MkngffControl(BaseControl):
         self.ctx.out(
             TEMPLATE.format(
                 OLD_FILESET=args.fileset_id,
-                PREFIX=f"{prefix_path}/{prefix_name}_converted/",
+                PREFIX=f"{prefix_path}/{prefix_name}_{SUFFIX}/",
                 ROWS=",\n".join(rows),
                 REPO=self.get_uuid(args),
                 UUID=args.secret,


### PR DESCRIPTION
Fixes #7.

NB: this branch is on top of #6.

As discussed on that issue, we need to always update the `pixels` table with `path/name` to a file in the new Fileset. It doesn't seem to matter too much which file is picked.
We pick the first `.zattrs` file we find (most top-level in `walk`) but if we find a `METADATA.ome.xml` then that is chosen in preference.
This logic is now in the main `def sql()` and outputs an extra `update` to the generated sql instead of being part of the `mkngff_fileset()` function in `setup.sql`.
 