### PR TITLE
No sql option

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -10,6 +10,31 @@ omero-mkngff
 Plugin to swap OMERO filesets with NGFF
 
 
+Usage
+=====
+
+To create sql containing required functions and run it:
+
+::
+
+    $ omero mkngff setup > setup.sql
+    $ psql -U omero -d idr -h $DBHOST -f setup.sql
+
+To generate sql and create the symlinks from the ManagedRepository to the NGFF data for a
+specified Fileset ID:
+
+::
+
+    $ omero mkngff sql --symlink_repo /OMERO/ManagedRepository --secret=secret 1234 /path/to/fileset.zarr > myNgff.sql
+    $ psql -U omero -d idr -h $DBHOST -f myNgff.sql
+
+To ONLY perform the symlink creation:
+
+::
+
+    $ omero mkngff symlink /OMERO/ManagedRepository 1234 /path/to/fileset.zarr
+
+
 Requirements
 ============
 

--- a/src/omero_mkngff/__init__.py
+++ b/src/omero_mkngff/__init__.py
@@ -232,6 +232,11 @@ class MkngffControl(BaseControl):
                 )
             )
 
+        # Add a command to update the Pixels table with path/name using old Fileset ID *before* new Fileset is created
+        fpath = setid_target[0]
+        fname = setid_target[1]
+        self.ctx.out(f"UPDATE pixels SET name = '{fname}', path = '{fpath}' where image in (select id from Image where fileset = {args.fileset_id});")
+
         self.ctx.out(
             TEMPLATE.format(
                 OLD_FILESET=args.fileset_id,
@@ -241,11 +246,6 @@ class MkngffControl(BaseControl):
                 UUID=args.secret,
             )
         )
-
-        # Add a command to update the Pixels table with path/name
-        fpath = setid_target[0]
-        fname = setid_target[1]
-        self.ctx.out(f"UPDATE pixels SET name = '{fname}', path = '{fpath}' where image in (select id from Image where fileset ={args.fileset_id});")
 
     def walk(self, path: Path) -> Generator[Tuple[Path, str, str], None, None]:
         for p in path.iterdir():


### PR DESCRIPTION
NB: this is on top of #8.

In cases where we've run a lengthy `omero mkngff sql...` command on e.g. a test server (e.g. `idr-testing`) and we wish to reuse the generated sql files on a different clean server (starting from the same state - same Fileset IDs, paths/to/fileset.zarr etc, we still need to create the symlinks on the new server, without walking the `fileset.zarr` which can take a long time.

This PR adds a `symlink` command to ONLY create symlinks.

E.g:

```
$ omero mkngff symlink /OMERO/ManagedRepository 1161 /path/to/fileset.zarr
```