### PR TITLE
Dont walk arrays

### DIFF
--- a/src/omero_mkngff/__init__.py
+++ b/src/omero_mkngff/__init__.py
@@ -174,7 +174,7 @@ class MkngffControl(BaseControl):
 
     def sql(self, args: Namespace) -> None:
         prefix = self.get_prefix(args)
-        self.ctx.err(f"Found prefix {prefix} for fileset {args.fileset_id}")
+        self.ctx.err(f"Found prefix {prefix} for fileset: {args.fileset_id}")
 
         symlink_path = Path(args.symlink_target)
 
@@ -288,11 +288,13 @@ class MkngffControl(BaseControl):
                 is_array = (p / ".zarray").exists()
                 if is_array or (p / ".zgroup").exists():
                     yield (p.parent, p.name, "Directory")
-                    # Don't try to walk zarray - will only contain chunks!
-                    if not is_array:
+                    # If array, don't recursively check sub-dirs
+                    if is_array:
+                        yield (p, ".zarray", "application/octet-stream")
+                    else:
                         yield from self.walk(p)
                 else:
-                    # Chunk directory
+                    # Non-zarr directory
                     continue
 
     def get_uuid(self, args: Namespace) -> str:

--- a/src/omero_mkngff/__init__.py
+++ b/src/omero_mkngff/__init__.py
@@ -147,7 +147,7 @@ class MkngffControl(BaseControl):
 
         sql = sub.add_parser("sql", help="generate SQL statement")
         sql.add_argument(
-            "--secret", help="DB UUID for protecting SQL statements", default="TBD"
+            "--secret", help="DB UUID for protecting SQL statements", default="SECRETUUID"
         )
         sql.add_argument("--zarr_name", help="Nicer name for zarr directory if desired")
         sql.add_argument(
@@ -174,7 +174,7 @@ class MkngffControl(BaseControl):
 
     def sql(self, args: Namespace) -> None:
         prefix = self.get_prefix(args)
-        self.ctx.err(f"Found prefix {prefix} for fileset: {args.fileset_id}")
+        self.ctx.err(f"Found prefix: {prefix} for fileset: {args.fileset_id}")
 
         symlink_path = Path(args.symlink_target)
 

--- a/src/omero_mkngff/__init__.py
+++ b/src/omero_mkngff/__init__.py
@@ -257,7 +257,7 @@ class MkngffControl(BaseControl):
         prefix_dir = os.path.join(symlink_repo, prefix)
         self.ctx.err(f"Checking for prefix_dir {prefix_dir}")
         if not os.path.exists(prefix_dir):
-                self.ctx.die(402, f"Fileset dir does not exist: {prefix_dir}")
+            self.ctx.die(402, f"Fileset dir does not exist: {prefix_dir}")
         symlink_container = f"{symlink_path.parent}"
         if symlink_container.startswith("/"):
             symlink_container = symlink_container[1:]  # remove "/" from start
@@ -270,7 +270,9 @@ class MkngffControl(BaseControl):
         self.ctx.err(
             f"Creating symlink {symlink_source} -> {symlink_target}"
         )
-        os.symlink(symlink_target, symlink_source, target_is_directory)
+        # ignore if symlink exists
+        if not os.path.exists(symlink_source):
+            os.symlink(symlink_target, symlink_source, target_is_directory)
 
     def walk(self, path: Path) -> Generator[Tuple[Path, str, str], None, None]:
         for p in path.iterdir():

--- a/src/omero_mkngff/__init__.py
+++ b/src/omero_mkngff/__init__.py
@@ -277,9 +277,12 @@ class MkngffControl(BaseControl):
             if not p.is_dir():
                 yield (p.parent, p.name, "application/octet-stream")
             else:
-                if (p / ".zarray").exists() or (p / ".zgroup").exists():
+                is_array = (p / ".zarray").exists()
+                if is_array or (p / ".zgroup").exists():
                     yield (p.parent, p.name, "Directory")
-                    yield from self.walk(p)
+                    # Don't try to walk zarray - will only contain chunks!
+                    if not is_array:
+                        yield from self.walk(p)
                 else:
                     # Chunk directory
                     continue


### PR DESCRIPTION
NB: this is on top of #9. 

Fixes #10.

This avoids traversing all the chunk directories under `.zarray` directory, which we know will only contain chunks.

