### PR TITLE
Add link to usage docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,6 +13,10 @@ Plugin to swap OMERO filesets with NGFF
 Usage
 =====
 
+For the full workflow used to update IDR with NGFF data, see 
+https://github.com/IDR/mkngff_upgrade_scripts.
+
+
 To create sql containing required functions and run it:
 
 ::


### PR DESCRIPTION
Adding a link to usage docs at https://github.com/IDR/mkngff_upgrade_scripts since I'd even forgotten about those instructions, and others certainly won't know to look there!