### PR TITLE
Alt store bfoptions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -22,17 +22,21 @@ To create sql containing required functions and run it:
 
 To generate sql and create the symlinks from the ManagedRepository to the NGFF data for a
 specified Fileset ID:
+The clientpath is used as the basis for the clientpath for each file in the Fileset. If omitted then
+the clientpath is 'unknown'. When writing .zarr.bfoptions into the ManagedRepository alongside the
+symlink to fileset.zarr, the clientpath will be added to bfoptions as `omezarr.alt_store`, allowing
+ZarrReader to read directly from that source.
 
 ::
 
-    $ omero mkngff sql --symlink_repo /OMERO/ManagedRepository --secret=secret --bfoptions 1234 /path/to/fileset.zarr > myNgff.sql
+    $ omero mkngff sql --symlink_repo /OMERO/ManagedRepository --secret=secret --bfoptions --clientpath=https://url/to/fileset.zarr 1234 /path/to/fileset.zarr > myNgff.sql
     $ psql -U omero -d idr -h $DBHOST -f myNgff.sql
 
-To ONLY perform the symlink creation (and optionally create fileset.zarr.bfoptions)
+To ONLY perform the symlink creation (and optionally create fileset.zarr.bfoptions with clientpath as above)
 
 ::
 
-    $ omero mkngff symlink /OMERO/ManagedRepository 1234 /path/to/fileset.zarr --bfoptions
+    $ omero mkngff symlink /OMERO/ManagedRepository 1234 /path/to/fileset.zarr --bfoptions --clientpath=https://url/to/fileset.zarr
 
 
 To ONLY create fileset.zarr.bfoptions

--- a/src/omero_mkngff/__init__.py
+++ b/src/omero_mkngff/__init__.py
@@ -260,19 +260,19 @@ class MkngffControl(BaseControl):
         if args.symlink_repo:
             self.create_symlink(args.symlink_repo, prefix, args.symlink_target)
             if args.bfoptions:
-                self.write_bfoptions(args.symlink_repo, prefix, args.symlink_target)
+                self.write_bfoptions(args.symlink_repo, prefix, args.symlink_target, args.clientpath)
 
     def bfoptions(self, args: Namespace) -> None:
         self.suffix = "" if args.fs_suffix == "None" else args.fs_suffix
         prefix = self.get_prefix(args)
-        self.write_bfoptions(args.symlink_repo, prefix, args.symlink_target)
+        self.write_bfoptions(args.symlink_repo, prefix, args.symlink_target, args.clientpath)
 
     def symlink(self, args: Namespace) -> None:
         self.suffix = "" if args.fs_suffix == "None" else args.fs_suffix
         prefix = self.get_prefix(args)
         self.create_symlink(args.symlink_repo, prefix, args.symlink_target)
         if args.bfoptions:
-            self.write_bfoptions(args.symlink_repo, prefix, args.symlink_target)
+            self.write_bfoptions(args.symlink_repo, prefix, args.symlink_target, args.clientpath)
 
     def get_prefix(self, args):
 
@@ -304,16 +304,19 @@ class MkngffControl(BaseControl):
         symlink_dir = f"{prefix_dir}{self.suffix}"
         return symlink_dir
 
-    def write_bfoptions(self, managed_repo, fsprefix, symlink_target):
+    def write_bfoptions(self, managed_repo, fsprefix, symlink_target, clientpath=None):
         file_path = Path(symlink_target)
         mkngff_dir = self.get_symlink_dir(managed_repo, fsprefix)
         # os.makedirs(mkngff_dir, exist_ok=True)
         zarr_path = os.path.join(mkngff_dir, file_path.name)
         bfoptions_path = f"{zarr_path}.bfoptions"
         self.ctx.err("write bfoptions to: %s" % bfoptions_path)
+        lines = ["omezarr.list_pixels=false\n",
+                 "omezarr.quick_read=true\n"]
+        if clientpath is not None:
+            lines.append("omezarr.alt_store={clientpath}\n")
         with open(bfoptions_path, "w") as f:
-            f.writelines(["omezarr.list_pixels=false",
-                          "\nomezarr.quick_read=true"])
+            f.writelines(lines)
 
     def create_symlink(self, symlink_repo, prefix, symlink_target):
         symlink_path = Path(symlink_target)

--- a/src/omero_mkngff/__init__.py
+++ b/src/omero_mkngff/__init__.py
@@ -182,6 +182,10 @@ class MkngffControl(BaseControl):
         symlink.add_argument("symlink_target")
         symlink.add_argument("--bfoptions", action="store_true", help="Create data.zarr.bfoptions file")
         symlink.add_argument("--fs_suffix", default="_mkngff", help=FS_SUFFIX_HELP)
+        symlink.add_argument(
+            "--clientpath",
+            help=("Adds omezarr.alt_store=clientpath/path/to/img.zarr to bfoptions")
+        )
         symlink.set_defaults(func=self.symlink)
 
         bfoptions = sub.add_parser("bfoptions", help="Create data.zarr.bfoptions in Fileset")

--- a/src/omero_mkngff/__init__.py
+++ b/src/omero_mkngff/__init__.py
@@ -199,7 +199,7 @@ class MkngffControl(BaseControl):
         symlink.add_argument("--fs_suffix", default="_mkngff", help=FS_SUFFIX_HELP)
         symlink.add_argument(
             "--clientpath",
-            help=("Adds omezarr.alt_store=clientpath/path/to/img.zarr to bfoptions")
+            help=("Adds omezarr.alt_store=clientpath/path/to/img.zarr to bfoptions"),
         )
         symlink.set_defaults(func=self.symlink)
 
@@ -294,22 +294,27 @@ class MkngffControl(BaseControl):
         if args.symlink_repo:
             self.create_symlink(args.symlink_repo, prefix, args.symlink_target)
             if args.bfoptions:
-                self.write_bfoptions(args.symlink_repo, prefix, args.symlink_target, args.clientpath)
+                self.write_bfoptions(
+                    args.symlink_repo, prefix, args.symlink_target, args.clientpath
+                )
 
     def bfoptions(self, args: Namespace) -> None:
         self.suffix = "" if args.fs_suffix == "None" else args.fs_suffix
         prefix = self.get_prefix(args)
-        self.write_bfoptions(args.symlink_repo, prefix, args.symlink_target, args.clientpath)
+        self.write_bfoptions(
+            args.symlink_repo, prefix, args.symlink_target, args.clientpath
+        )
 
     def symlink(self, args: Namespace) -> None:
         self.suffix = "" if args.fs_suffix == "None" else args.fs_suffix
         prefix = self.get_prefix(args)
         self.create_symlink(args.symlink_repo, prefix, args.symlink_target)
         if args.bfoptions:
-            self.write_bfoptions(args.symlink_repo, prefix, args.symlink_target, args.clientpath)
+            self.write_bfoptions(
+                args.symlink_repo, prefix, args.symlink_target, args.clientpath
+            )
 
     def get_prefix(self, args):  # type: ignore
-
         conn = self.ctx.conn(args)  # noqa
         q = conn.sf.getQueryService()
         rv = q.findAllByQuery(
@@ -338,15 +343,14 @@ class MkngffControl(BaseControl):
         symlink_dir = f"{prefix_dir}{self.suffix}"
         return symlink_dir
 
-    def write_bfoptions(self, managed_repo, fsprefix, symlink_target, clientpath=None): # type: ignore # noqa
+    def write_bfoptions(self, managed_repo, fsprefix, symlink_target, clientpath=None):  # type: ignore # noqa
         file_path = Path(symlink_target)
         mkngff_dir = self.get_symlink_dir(managed_repo, fsprefix)
         # os.makedirs(mkngff_dir, exist_ok=True)
         zarr_path = os.path.join(mkngff_dir, file_path.name)
         bfoptions_path = f"{zarr_path}.bfoptions"
         self.ctx.err("write bfoptions to: %s" % bfoptions_path)
-        lines = ["omezarr.list_pixels=false\n",
-                 "omezarr.quick_read=true\n"]
+        lines = ["omezarr.list_pixels=false\n", "omezarr.quick_read=true\n"]
         if clientpath is not None:
             lines.append("omezarr.alt_store=%s\n" % clientpath)
         with open(bfoptions_path, "w") as f:

--- a/src/omero_mkngff/__init__.py
+++ b/src/omero_mkngff/__init__.py
@@ -318,7 +318,7 @@ class MkngffControl(BaseControl):
         lines = ["omezarr.list_pixels=false\n",
                  "omezarr.quick_read=true\n"]
         if clientpath is not None:
-            lines.append("omezarr.alt_store={clientpath}\n")
+            lines.append("omezarr.alt_store=%s\n" % clientpath)
         with open(bfoptions_path, "w") as f:
             f.writelines(lines)
 


### PR DESCRIPTION
Fixes #15.

Add support for adding the `clientpath` as the `omezarr.alt_store` to the bfoptions file created beside the symlink.

See https://github.com/ome/ZarrReader/pull/82